### PR TITLE
Allow making comments as active

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ When extension is added to your organization then you can find it from the exten
 ```
 - task: PullRequestComment@1
   inputs:
+    active: false
     comment: |
       This is **sample** _text_ 🎉
       [This is link](https://microsoft.com)

--- a/buildandreleasetask/index.ts
+++ b/buildandreleasetask/index.ts
@@ -19,7 +19,8 @@ async function run() {
     const collectionUri = tl.getVariable('System.CollectionUri') ?? ''
     const repositoryId = tl.getVariable('Build.Repository.ID') ?? ''
     const connection = new azdev.WebApi(collectionUri, authHandler)
-    const gitApi = await connection.getGitApi()    
+    const gitApi = await connection.getGitApi()
+    const isActive = tl.getBoolInput('active', false)
     const thread : any = {
       comments: [{
         commentType: CommentType.Text,
@@ -27,7 +28,7 @@ async function run() {
       }],
       lastUpdatedDate: new Date(),
       publishedDate: new Date(),
-      status: CommentThreadStatus.Closed,
+      status: isActive ? CommentThreadStatus.Active : CommentThreadStatus.Closed,
     }
     const t = await gitApi.createThread(thread, repositoryId, pullRequestId)
     console.log(`Comment added on pull request: ${comment}`)

--- a/buildandreleasetask/task.json
+++ b/buildandreleasetask/task.json
@@ -9,8 +9,8 @@
   "author": "Tommi Laukkanen",
   "version": {
     "Major": 1,
-    "Minor": 0,
-    "Patch": 22
+    "Minor": 1,
+    "Patch": 0
   },
   "instanceNameFormat": "PR Comment",
   "inputs": [
@@ -25,6 +25,14 @@
       "defaultValue": "This is **sample** _text_",
       "required": true,
       "helpMarkDown": "Specify a comment to be added on pull request"
+    },
+    {
+      "name": "active",
+      "type": "boolean",
+      "defaultValue": false,
+      "label": "Active",
+      "required": false,
+      "helpMarkDown": "If checked, the comment will be added as active. Otherwise, it will be added as a closed comment."
     }
   ],
   "execution": {

--- a/buildandreleasetask/tests/success.ts
+++ b/buildandreleasetask/tests/success.ts
@@ -6,4 +6,5 @@ let taskPath = path.join(__dirname, '..', 'index.js');
 let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
 tmr.setInput('comment', 'Test');
+tmr.setInput('active', 'true');
 tmr.run();

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "pr-comment-extension",
   "publisher": "TommiLaukkanen",
-  "version": "1.0.22",
+  "version": "1.1.0",
   "name": "PR Comment Task",
   "description": "Azure DevOps extension to easily add pull request comments from pipeline task",
   "public": true,


### PR DESCRIPTION
This allows making comments as active instead of closed (which will remain as default state).
Sample how this can be used in pipeline:
```
- task: PullRequestComment@1
  inputs:
    active: true
    comment: |
      This is my **active** comment
  displayName: 'PR Comment'
```