### PR TITLE
Update PR comment task logic to support new property naming and increment version to 1.4.2

### DIFF
--- a/buildandreleasetask/task.json
+++ b/buildandreleasetask/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 4,
-    "Patch": 1
+    "Patch": 2
   },
   "instanceNameFormat": "PR Comment",
   "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "pr-comment-extension",
   "publisher": "TommiLaukkanen",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "name": "PR Comment Task",
   "description": "Azure DevOps extension to easily add pull request comments from pipeline task",
   "public": true,


### PR DESCRIPTION
This pull request includes several changes to improve the logging and update the properties used in the `buildandreleasetask` module. The most important changes include adding detailed logging to the `run` function, updating the property key used for pull request comments, and incrementing the version numbers in the configuration files.

### Logging Improvements:
* Added log statements to check for threads with the comment task property in the `run` function. (`buildandreleasetask/index.ts`) [[1]](diffhunk://#diff-53444d17ddac48b96d2849941edd853aad326ca5b9a7d034d530b96468372975R46-R50) [[2]](diffhunk://#diff-53444d17ddac48b96d2849941edd853aad326ca5b9a7d034d530b96468372975R62-R78)

### Property Key Update:
* Changed the property key from `'pr-comment-task'` to `'PullRequestCommentTask'` in the `run` function and thread creation. (`buildandreleasetask/index.ts`)

### Version Increment:
* Updated the patch version in `task.json` from `1.4.1` to `1.4.2`. (`buildandreleasetask/task.json`)
* Updated the version in `vss-extension.json` from `1.4.1` to `1.4.2`. (`vss-extension.json`)